### PR TITLE
Behat context: edge case fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ default:
        }
    }
 
-   $toggleCollection = new SessionFeatureToggleCollection();
+   $toggleCollection = new CacheFeatureToggleCollection();
    $toggleCollection->setCacheItemPool($psr6CacheItemPool);
 
-   // Overwrite the FeatureToggleCollection with the SessionFeatureToggleCollection in test env
+   // Overwrite the FeatureToggleCollection with the CacheFeatureToggleCollection in test env
    new Feature($toggleCollection);
 ```
 

--- a/src/TreeHouse/FeatureToggle/Bridge/Behat/CacheFeatureToggleCollection.php
+++ b/src/TreeHouse/FeatureToggle/Bridge/Behat/CacheFeatureToggleCollection.php
@@ -5,7 +5,7 @@ namespace TreeHouse\FeatureToggle\Bridge\Behat;
 use Psr\Cache\CacheItemPoolInterface;
 use TreeHouse\FeatureToggle\FeatureToggleCollection;
 
-class SessionFeatureToggleCollection extends FeatureToggleCollection
+class CacheFeatureToggleCollection extends FeatureToggleCollection
 {
     /**
      * @var CacheItemPoolInterface

--- a/src/TreeHouse/FeatureToggle/Bridge/Behat/SessionFeatureToggleCollection.php
+++ b/src/TreeHouse/FeatureToggle/Bridge/Behat/SessionFeatureToggleCollection.php
@@ -19,7 +19,7 @@ class SessionFeatureToggleCollection extends FeatureToggleCollection
     {
         $item = $this->cacheItemPool->getItem('feature-toggles');
 
-        return in_array($name, $item->get());
+        return in_array($name, (array) $item->get()) || !parent::has($name);
     }
 
     /**


### PR DESCRIPTION
It is possible that an item returns `null` if no toggles have been instantiated at all, this ensures the `in_array` call still works by casting it to an empty array. 