### PR TITLE
Symfony application shortcut function

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ composer require treehouselabs/feature-toggle
 
 ## Usage
 
+
+### Simple 
+
 ```php
 $features = new FeatureToggleCollection();
 $features->registerToggle(
@@ -28,6 +31,73 @@ if ($features->isEnabled('feature-x')) {
     // perform stuff for feature-x
 }
 
+```
+
+### Symfony application
+
+In app/config/services.yml add
+
+```yaml
+services:
+  feature_toggles.collection:
+    class: TreeHouse\FeatureToggle\FeatureToggleCollection
+  
+  feature_toggles.toggle.dont_allow:
+    class: TreeHouse\FeatureToggle\BooleanFeatureToggle
+    arguments: [false]
+    tags:
+      - { name: feature_toggle, alias: 'feature-x' }
+      
+  app.twig_extension.feature_toggle:
+     class: TreeHouse\FeatureToggle\Bridge\Twig\FeatureToggleExtension
+     arguments:
+       - '@feature_toggles.collection'
+     tags:
+       - { name: twig.extension }   
+```
+
+In composer.json autoload the shortcut function (so you don't have to inject the FeatureCollection everywhere)
+
+```json
+{
+  "autoload": {
+    "files": ["vendor/treehouselabs/feature-toggle/src/TreeHouse/FeatureToggle/Bridge/HttpKernel/functions.php"]
+  }
+}
+```
+
+Register compiler pass in your AppBunde.php
+
+```php
+use TreeHouse\FeatureToggle\Bridge\DependencyInjection\RegisterFeatureTogglesCompilerPass;
+
+class AppBundle extends Bundle
+{
+    ...
+    public function build(ContainerBuilder $container)
+    {
+        ...
+        $container->addCompilerPass(new RegisterFeatureTogglesCompilerPass('feature_toggles.collection'));
+        ...
+    }
+    ...
+}
+```
+
+Check feature from any php file in your symfony project:
+
+```php
+if (\TreeHouse\FeatureToggle\Bridge\HttpKernel\toggle('feature-x')) {
+    // perform stuff for feature-x
+}
+```
+
+Or in your twig templates with:
+
+```twig
+{% if toggle('feature-x') %}
+  Do stuff
+{% endif %}
 ```
 
 ### Behat context

--- a/src/TreeHouse/FeatureToggle/Bridge/HttpKernel/ToggleFunctionConfig.php
+++ b/src/TreeHouse/FeatureToggle/Bridge/HttpKernel/ToggleFunctionConfig.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types = 1);
+
+namespace TreeHouse\FeatureToggle\Bridge\HttpKernel;
+
+abstract class ToggleFunctionConfig
+{
+    /**
+     * @var string
+     */
+    private static $serviceId = 'feature_toggles.collection';
+
+    /**
+     * @param string $name
+     */
+    public static function setServiceId($name)
+    {
+        self::$serviceId = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public static function getServiceId()
+    {
+        return self::$serviceId;
+    }
+}

--- a/src/TreeHouse/FeatureToggle/Bridge/HttpKernel/functions.php
+++ b/src/TreeHouse/FeatureToggle/Bridge/HttpKernel/functions.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * To make use of this toggle function shortcut, append path to this file in your composer.json
+ * ie:
+ * {
+ *  "autoload": {
+ *    "files": ["vendor/treehouselabs/feature-toggle/src/TreeHouse/FeatureToggle/Bridge/HttpKernel/functions.php"]
+ *  }
+ * }
+ */
+
+namespace TreeHouse\FeatureToggle\Bridge\HttpKernel;
+
+use TreeHouse\FeatureToggle\FeatureToggleCollectionInterface;
+
+/**
+ * To make use of
+ *
+ * @param string $name
+ *
+ * @return bool
+ */
+function toggle($name)
+{
+    global $kernel;
+
+    if (!$kernel) {
+        throw new \RuntimeException('No kernel found, are you in a Symfony environment?');
+    }
+
+    /** @var FeatureToggleCollectionInterface $toggles */
+    $toggles = $kernel->getContainer()->get(ToggleFunctionConfig::getServiceId());
+
+    return $toggles->isEnabled($name);
+}

--- a/src/TreeHouse/FeatureToggle/FeatureToggleCollectionInterface.php
+++ b/src/TreeHouse/FeatureToggle/FeatureToggleCollectionInterface.php
@@ -13,6 +13,8 @@ interface FeatureToggleCollectionInterface
     /**
      * @param string $name
      * @param array  $context
+     *
+     * @return bool
      */
     public function isEnabled($name, array $context = []);
 


### PR DESCRIPTION
Added shortcut function which uses global $container for easier access
to the feature toggle collection. So we don't have to inject the
toggle collection in every class, which saves time cleaning stuff up.

Also added some basic documentation how to configure in your Symfony
application.